### PR TITLE
Uncertainty patch

### DIFF
--- a/group_aggregator.py
+++ b/group_aggregator.py
@@ -293,7 +293,7 @@ def get_continuum_idx(wavelengths: np.array, feature: tuple, valid_wavelengths: 
         return left_inds, right_inds
 
     if len(left_inds) == 0:
-        interior_left = wavelengths - feature['continuum'][1]
+        interior_left = wavelengths - feature[1]
         interior_left[interior_left < 0] = np.nan
         if np.all(np.isnan(interior_left)):
             return None
@@ -302,7 +302,7 @@ def get_continuum_idx(wavelengths: np.array, feature: tuple, valid_wavelengths: 
             return interior_left, right_inds
 
     if len(right_inds) == 0:
-        interior_right = feature['continuum'][2] - wavelengths
+        interior_right = feature[2] - wavelengths
         interior_right[interior_right < 0] = np.nan
         if np.all(np.isnan(interior_right)):
             return None

--- a/group_aggregator.py
+++ b/group_aggregator.py
@@ -268,7 +268,7 @@ def cont_rem(wavelengths: np.array, reflectance: np.array, continuum_idx, valid_
     
     feature_inds = np.where(np.logical_and.reduce((np.arange(len(valid_wavelengths)) >= left_inds[0], 
                                                    np.arange(len(valid_wavelengths)) <= right_inds[1],
-                                                   valid_wavelengths)))
+                                                   valid_wavelengths)))[0]
 
     continuum_fun = interp1d([left_x, right_x], [left_y, right_y], bounds_error=False, fill_value='extrapolate')
     continuum = continuum_fun( np.ones((reflectance.shape[0], len(feature_inds))) * wavelengths[feature_inds][np.newaxis,:])

--- a/group_aggregator.py
+++ b/group_aggregator.py
@@ -272,7 +272,7 @@ def cont_rem(wavelengths: np.array, reflectance: np.array, continuum_idx, valid_
 
     continuum_fun = interp1d([left_x, right_x], [left_y, right_y], bounds_error=False, fill_value='extrapolate')
     continuum = continuum_fun( np.ones((reflectance.shape[0], len(feature_inds))) * wavelengths[feature_inds][np.newaxis,:])
-    depths = 1 - reflectance[:,feature_inds] / continuum, feature_inds
+    depths = 1 - reflectance[:,feature_inds] / continuum
     return depths, feature_inds
 
 

--- a/group_aggregator.py
+++ b/group_aggregator.py
@@ -267,7 +267,7 @@ def cont_rem(wavelengths: np.array, reflectance: np.array, continuum_idx, valid_
     right_y = reflectance[:,right_inds].mean()
     
     feature_inds = np.where(np.logical_and.reduce((np.arange(len(valid_wavelengths)) >= left_inds[0], 
-                                                   np.arange(len(valid_wavelengths)) <= right_inds[1],
+                                                   np.arange(len(valid_wavelengths)) <= right_inds[-1],
                                                    valid_wavelengths)))[0]
 
     continuum_fun = interp1d([left_x, right_x], [left_y, right_y], bounds_error=False, fill_value='extrapolate')


### PR DESCRIPTION
Enables uncertainty calculations when the continuum definitions miss a wavelength center, by using the interior wavelength position.